### PR TITLE
Fix bitter melon

### DIFF
--- a/app/src/main/res/raw/japan.json
+++ b/app/src/main/res/raw/japan.json
@@ -86,9 +86,9 @@
     {
       "name": "bitter_melon",
       "months": [
-        0,
-        1,
-        2
+        6,
+        7,
+        8
       ]
     },
     {


### PR DESCRIPTION
Originally on 7/8/9 though put on wrong positions and thus converted as 1/2/3 which is wrong.