### PR TITLE
Add Northwestern Europe (temperate) seasonal calendar

### DIFF
--- a/app/src/main/res/raw/northwestern_europe_temperate.json
+++ b/app/src/main/res/raw/northwestern_europe_temperate.json
@@ -1,0 +1,284 @@
+{
+  "food": [
+    {
+      "name": "apple",
+      "months": [8, 9, 10]
+    },
+    {
+      "name": "asparagus",
+      "months": [3, 4]
+    },
+    {
+      "name": "aubergine",
+      "months": [7]
+    },
+    {
+      "name": "autumn-fruiting_raspberry",
+      "months": [8, 9]
+    },
+    {
+      "name": "baby_carrot",
+      "months": [5]
+    },
+    {
+      "name": "beetroot",
+      "months": [6, 7, 8, 9]
+    },
+    {
+      "name": "blackberry",
+      "months": [7]
+    },
+    {
+      "name": "bluberry",
+      "months": [7, 8]
+    },
+    {
+      "name": "blueberry",
+      "months": [6]
+    },
+    {
+      "name": "broad_bean",
+      "months": [5]
+    },
+    {
+      "name": "broccoli",
+      "months": [7, 8, 9]
+    },
+    {
+      "name": "brussel_sprout",
+      "months": [0, 1, 11]
+    },
+    {
+      "name": "cabbage",
+      "months": [6, 7, 8, 9, 10]
+    },
+    {
+      "name": "carrot",
+      "months": [0, 6, 7, 8, 9, 10, 11]
+    },
+    {
+      "name": "cauliflower",
+      "months": [0, 1, 2, 7, 8, 9, 10, 11]
+    },
+    {
+      "name": "celeriac",
+      "months": [9]
+    },
+    {
+      "name": "celery",
+      "months": [7, 8, 9]
+    },
+    {
+      "name": "chard",
+      "months": [5, 7, 8, 9]
+    },
+    {
+      "name": "cherry",
+      "months": [6]
+    },
+    {
+      "name": "chilly",
+      "months": [7, 8, 9]
+    },
+    {
+      "name": "courgette",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "cucumber",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "currant",
+      "months": [5, 6]
+    },
+    {
+      "name": "damson",
+      "months": [8]
+    },
+    {
+      "name": "fennel",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "fig",
+      "months": [8]
+    },
+    {
+      "name": "forced_rhubarb",
+      "months": [2]
+    },
+    {
+      "name": "french_bean",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "garlic",
+      "months": [8]
+    },
+    {
+      "name": "gooseberry",
+      "months": [5, 6]
+    },
+    {
+      "name": "jerusalem_artichoke",
+      "months": [9]
+    },
+    {
+      "name": "kale",
+      "months": [0, 1, 2, 9, 10, 11]
+    },
+    {
+      "name": "kohl_rabi",
+      "months": [9]
+    },
+    {
+      "name": "leek",
+      "months": [1, 2, 9, 10, 11]
+    },
+    {
+      "name": "lettuce",
+      "months": [4, 5, 6, 7, 8]
+    },
+    {
+      "name": "loganberry",
+      "months": [6]
+    },
+    {
+      "name": "mangetout",
+      "months": [6, 7]
+    },
+    {
+      "name": "marrow",
+      "months": [9]
+    },
+    {
+      "name": "new_potato",
+      "months": [6]
+    },
+    {
+      "name": "onion",
+      "months": [8, 9]
+    },
+    {
+      "name": "pak_choi",
+      "months": [9]
+    },
+    {
+      "name": "parsley",
+      "months": [5]
+    },
+    {
+      "name": "parsnip",
+      "months": [0, 1, 9, 10]
+    },
+    {
+      "name": "pea",
+      "months": [6, 7]
+    },
+    {
+      "name": "pear",
+      "months": [8, 9, 10]
+    },
+    {
+      "name": "pepper",
+      "months": [7, 8]
+    },
+    {
+      "name": "plum",
+      "months": [7, 8]
+    },
+    {
+      "name": "potato",
+      "months": [7, 8, 10, 11]
+    },
+    {
+      "name": "potato_(maincrop)",
+      "months": [9]
+    },
+    {
+      "name": "pumpkin",
+      "months": [9]
+    },
+    {
+      "name": "purple_sprouting_broccoli",
+      "months": [1, 2, 3]
+    },
+    {
+      "name": "quince",
+      "months": [9]
+    },
+    {
+      "name": "radish",
+      "months": [4, 5, 6]
+    },
+    {
+      "name": "raspberry",
+      "months": [6, 7]
+    },
+    {
+      "name": "rhubarb",
+      "months": [3, 4]
+    },
+    {
+      "name": "rocket",
+      "months": [5, 9]
+    },
+    {
+      "name": "runner_bean",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "savoy_cabbage",
+      "months": [0, 1, 2, 11]
+    },
+    {
+      "name": "shallot",
+      "months": [6, 8, 9]
+    },
+    {
+      "name": "spinach",
+      "months": [4, 5, 6, 8, 9]
+    },
+    {
+      "name": "spring_cabbage",
+      "months": [3, 4, 5]
+    },
+    {
+      "name": "spring_onion",
+      "months": [3, 4, 5, 6, 7]
+    },
+    {
+      "name": "strawberry",
+      "months": [5]
+    },
+    {
+      "name": "summer_squash",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "swede",
+      "months": [0, 9]
+    },
+    {
+      "name": "sweetcorn",
+      "months": [7, 8]
+    },
+    {
+      "name": "tayberry",
+      "months": [6]
+    },
+    {
+      "name": "tomato",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "turnip",
+      "months": [9]
+    },
+    {
+      "name": "winter_squash",
+      "months": [9]
+    }
+  ]
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="seasons_feedback_subject">Feedback for Seasonal Calendar</string>
 
     <string name="region_central_europe">Central Europe</string>
+    <string name="region_northwestern_europe_temperate">Northwestern Europe (temperate)</string>
     <string name="region_north_america_colder">North America (colder)</string>
     <string name="region_north_america_warmer">North America (warmer)</string>
     <string name="region_japan">Japan</string>


### PR DESCRIPTION
This is the Northwestern Europe temperate as depicted on [this](https://en.wikipedia.org/wiki/Climate_of_Europe#/media/File:Koppen-Geiger_Map_v2_Europe_1991%E2%80%932020.svg) map.

Currently the list of sources are:
* [National Trust: Guide to seasonal food](https://www.nationaltrust.org.uk/discover/gardening-tips/guide-to-seasonal-food)
* [The Association of UK Dietitians](https://www.bda.uk.com/food-health/your-health/sustainable-diets/seasonal-fruit-and-veg-a-handy-guide.html#:~:text=Seasonal%20fruit%3A%20Apples%2C%20Pears)

Some more things to consider:

- [ ] Make the plant names consistent e.g. courgette and zucchini?
- [ ] Make varieties consistent e.g. winter and summery squash or new potato
- [ ] Make different lists consistent
- [ ] Research sources from mainland continent
- [ ] Add translations of the zone
- [ ] ???