### PR TITLE
Fix: Prevent 404 error when importing recipes with encoded URLs

### DIFF
--- a/app/src/main/java/com/flauschcode/broccoli/recipe/importing/RecipeImportService.java
+++ b/app/src/main/java/com/flauschcode/broccoli/recipe/importing/RecipeImportService.java
@@ -15,6 +15,8 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -42,9 +44,14 @@ public class RecipeImportService {
         return CompletableFuture.supplyAsync(() -> {
             Document document;
             try {
-                document = Jsoup.connect(url).userAgent(USER_AGENT).get();
-            } catch (IOException e) {
-                throw new CompletionException(e);
+                String decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8.name());
+                document = Jsoup.connect(decodedUrl).userAgent(USER_AGENT).get();
+            } catch (IOException | IllegalArgumentException e) {
+                try {
+                    document = Jsoup.connect(url).userAgent(USER_AGENT).get();
+                } catch (IOException ex) {
+                    throw new CompletionException(ex);
+                }
             }
 
             Elements jsonLds = document.select("script[type=\"application/ld+json\"]");


### PR DESCRIPTION
Jsoup was double-encoding URLs that already contained percent-encoded characters (such as Greek letters), leading to 404 errors during the initial document fetch.

This change decodes the URL once before passing it to Jsoup, ensuring it is encoded exactly once correctly.

Tested on the recipes below,
- [Galaktoboureko](https://miakouppa.com/galaktoboureko-%ce%b3%ce%b1%ce%bb%ce%b1%ce%ba%cf%84%ce%bf%ce%bc%cf%80%ce%bf%cf%8d%cf%81%ce%b5%ce%ba%ce%bf/)
- [Walnut Cake](https://miakouppa.com/walnut-cake-karydopita-%ce%ba%ce%b1%cf%81%cf%85%ce%b4%cf%8c%cf%80%ce%b9%cf%84%ce%b1/)
