### PR TITLE
feat(seasonal-calendar): add Mediterranean region

### DIFF
--- a/app/src/main/res/raw/mediterranean.json
+++ b/app/src/main/res/raw/mediterranean.json
@@ -1,0 +1,224 @@
+{
+  "food": [
+    {
+      "name": "mallow",
+      "months": [1, 2, 3]
+    },
+    {
+      "name": "artichoke",
+      "months": [2, 3, 4]
+    },
+    {
+      "name": "asparagus",
+      "months": [2, 3, 4]
+    },
+    {
+      "name": "broad_bean",
+      "months": [2, 3, 4]
+    },
+    {
+      "name": "dill",
+      "months": [2, 3, 4, 5, 6]
+    },
+    {
+      "name": "lettuce",
+      "months": [2, 3, 4, 8, 9, 10]
+    },
+    {
+      "name": "rocket",
+      "months": [2, 3, 4, 8, 9, 10]
+    },
+    {
+      "name": "pea",
+      "months": [3, 4, 5]
+    },
+    {
+      "name": "cherry",
+      "months": [3, 4]
+    },
+    {
+      "name": "strawberry",
+      "months": [3, 4]
+    },
+    {
+      "name": "apricot",
+      "months": [3, 4, 5]
+    },
+    {
+      "name": "bean",
+      "months": [4, 5, 6, 7]
+    },
+    {
+      "name": "cucumber",
+      "months": [4, 5, 6, 7, 8]
+    },
+    {
+      "name": "potato",
+      "months": [4, 5, 6, 7, 8, 9]
+    },
+    {
+      "name": "purslane",
+      "months": [4, 5, 6, 7, 8]
+    },
+    {
+      "name": "zucchini",
+      "months": [4, 5, 6, 7]
+    },
+    {
+      "name": "loquat",
+      "months": [4, 5]
+    },
+    {
+      "name": "bell_pepper",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "cowpea",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "tomato",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "eggplant",
+      "months": [5, 6, 7, 8, 9]
+    },
+    {
+      "name": "melon",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "peach",
+      "months": [5, 6, 7]
+    },
+    {
+      "name": "watermelon",
+      "months": [5, 6, 7, 8]
+    },
+    {
+      "name": "corn",
+      "months": [6, 7, 8, 9]
+    },
+    {
+      "name": "plum",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "fig",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "grape",
+      "months": [6, 7, 8]
+    },
+    {
+      "name": "apple",
+      "months": [6, 7, 8, 9, 10]
+    },
+    {
+      "name": "pear",
+      "months": [6, 7, 8, 9, 10]
+    },
+    {
+      "name": "okra",
+      "months": [7, 8, 9]
+    },
+    {
+      "name": "lemon",
+      "months": [8, 9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "quince",
+      "months": [8, 9, 10]
+    },
+    {
+      "name": "persimmon",
+      "months": [8, 9, 10]
+    },
+    {
+      "name": "pomegranate",
+      "months": [8, 9, 10, 11]
+    },
+    {
+      "name": "broccoli",
+      "months": [8, 9, 10, 11, 0, 1]
+    },
+    {
+      "name": "carrot",
+      "months": [8, 9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "celery",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "celeriac",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "leek",
+      "months": [8, 9, 10, 11, 0, 1, 2, 3, 4]
+    },
+    {
+      "name": "spring_onion",
+      "months": [8, 9, 10, 11, 0, 1, 2, 3, 4]
+    },
+    {
+      "name": "fennel",
+      "months": [10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "wild_fennel",
+      "months": [10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "mandarin",
+      "months": [9, 10, 11, 0, 1]
+    },
+    {
+      "name": "chestnut",
+      "months": [9, 10, 11]
+    },
+    {
+      "name": "beetroot",
+      "months": [9, 10, 11, 0, 1, 2]
+    },
+    {
+      "name": "cauliflower",
+      "months": [9, 10, 11, 0, 1, 2]
+    },
+    {
+      "name": "chard",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "cabbage",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "white_cabbage",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "red_cabbage",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "spinach",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "radish",
+      "months": [9, 10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "grapefruit",
+      "months": [10, 11, 0, 1, 2, 3]
+    },
+    {
+      "name": "orange",
+      "months": [11, 0, 1, 2, 3, 4]
+    }
+  ]
+}

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -113,6 +113,7 @@
     <string name="seasons_feedback_message">Bölgeniz, diliniz veya favori malzemeniz eksik mi?</string>
     <string name="seasons_feedback_subject">Mevsimsel Takvim için Geri Bildirim</string>
     <string name="region_central_europe">Orta Avrupa</string>
+    <string name="region_mediterranean">Akdeniz</string>
     <string name="region_north_america_colder">Kuzey Amerika (daha soğuk)</string>
     <string name="region_north_america_warmer">Kuzey Amerika (daha sıcak)</string>
     <string name="region_japan">Japonya</string>
@@ -955,5 +956,33 @@
     <string name="yuzu">Yuzu</string>
     <!-- ONLY RELEVANT FOR THE JAPANESE SEASONAL CALENDAR Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms), see https://en.wikipedia.org/wiki/Yuzu. -->
     <string name="yuzu_terms">yuzu</string>
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="artichoke">Enginar</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="artichoke_terms">enginar</string>
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="cowpea">Börülce</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="cowpea_terms">börülce</string>
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="grapefruit">Greyfurt</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="grapefruit_terms">greyfurt</string>
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="mallow">Ebegümeci</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="mallow_terms">ebegümeci</string>
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="purslane">Semizotu</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="purslane_terms">semizotu, semiz</string>  
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="quince">Ayva</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="quince_terms">ayva</string>
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="wild_fennel">Arapsaçı</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="wild_fennel_terms">arapsaçı, yabani rezene</string>
     <string name="create_pdf">PDF Oluştur</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -3,6 +3,7 @@
 
     <string-array name="region_labels">
         <item>@string/region_central_europe</item>
+        <item>@string/region_mediterranean</item>
         <item>@string/region_north_america_colder</item>
         <item>@string/region_north_america_warmer</item>
         <item>@string/region_japan</item>
@@ -10,6 +11,7 @@
 
     <string-array name="region_values">
         <item>central_europe</item>
+        <item>mediterranean</item>
         <item>north_america_colder</item>
         <item>north_america_warmer</item>
         <item>japan</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="seasons_feedback_subject">Feedback for Seasonal Calendar</string>
 
     <string name="region_central_europe">Central Europe</string>
+    <string name="region_mediterranean">Mediterranean</string>
     <string name="region_north_america_colder">North America (colder)</string>
     <string name="region_north_america_warmer">North America (warmer)</string>
     <string name="region_japan">Japan</string>
@@ -209,7 +210,7 @@
     <!-- A title for the ingredient list in the seasonal calendar. -->
     <string name="fennel">Fennel</string>
     <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
-    <string name="fennel_terms">fennel</string>
+    <string name="fennel_terms">fennel</string>    
 
     <!-- A title for the ingredient list in the seasonal calendar. -->
     <string name="kale">Kale</string>
@@ -249,7 +250,7 @@
     <!-- A title for the ingredient list in the seasonal calendar. -->
     <string name="chard">Chard</string>
     <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
-    <string name="chard_terms">chard</string>
+    <string name="chard_terms">chard, swiss chard</string>
 
     <!-- A title for the ingredient list in the seasonal calendar. -->
     <string name="carrot">Carrots</string>
@@ -1185,6 +1186,42 @@
     <string name="yuzu">Yuzu</string>
     <!-- ONLY RELEVANT FOR THE JAPANESE SEASONAL CALENDAR Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms), see https://en.wikipedia.org/wiki/Yuzu. -->
     <string name="yuzu_terms">yuzu</string>
+
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="artichoke">Artichoke</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="artichoke_terms">artichoke, artichokes, globe artichoke</string>
+
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="cowpea">Cowpea</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="cowpea_terms">cowpea, cowpeas</string>
+    
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="grapefruit">Grapefruit</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="grapefruit_terms">grapefruit, grapefruits</string>
+
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="mallow">Mallow</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="mallow_terms">mallow, common mallow</string>
+
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="purslane">Purslane</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="purslane_terms">purslane, purslanes</string>
+
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="quince">Quince</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="quince_terms">quince, quinces</string>
+
+    <!-- A title for the ingredient list in the seasonal calendar. -->
+    <string name="wild_fennel">Wild Fennel</string>
+    <!-- Search terms used to identify seasonal ingredients in recipes (should include plural forms or synonyms). -->
+    <string name="wild_fennel_terms">wild fennel</string>
+
     <string name="create_pdf">Create PDF</string>
 
 </resources>


### PR DESCRIPTION
feat(seasonal-calendar): add Mediterranean region dataset and translations

- Add `mediterranean.json` raw resource containing seasonal food data
- Update `arrays.xml` to include the Mediterranean region entry and value
- Add missing string resources for region labels and new ingredients (Artichoke, Cowpea, Grapefruit, Mallow, Purslane, Quince, Wild Fennel) in `strings.xml` and Turkish localization `strings.xml`